### PR TITLE
Escapes invalid class characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = function () {
-  return function({ addVariant }) {
+  return function({ addVariant, e }) {
       addVariant('open', ({ modifySelectors, separator }) => {
           modifySelectors(({ className }) => {
-              return `[open].open${separator}${className}[open], details[open] .open${separator}${className}`
+              return `[open].open${e(`${separator}${className}`)}[open], details[open] .open${e(`${separator}${className}`)}`
           })
       })
   }


### PR DESCRIPTION
## Pull request type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What does it change?

`tailwindcss-open-variant` currently produces classes like this one:

```
[open].open:rotate-90[open], details[open] .open:rotate-90
```

The colons are invalid in CSS and need to be escaped. Tailwind's `e` helper was designed for this use case. My commit produces classes like this:

```
[open].open\:rotate-90[open], details[open] .open\:rotate-90
```

With the colons escaped, the CSS is valid.

## Why this PR?

See above

## How has this been tested?

Tested manually in one of my apps.

## Checklist

To facilitate merging your change and the approval of this PR, please make sure you've reviewed and applied the following:

- This PR addresses exactly one issue
- All changes were made in a fork of this project (preferably also in a separate branch)
- It follows the code style of this project
- Tests were added to cover the changes
- All previously existing tests still pass
- If the change to the code requires a change to the documentation, it has been updated accordingly
- You have read the notes on contributing to the project and adhere to the rules laid out

If you're unsure about any of these, don't hesitate to ask. We're here to help!
